### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These users have approval access to all resources (wildcard)
-* @ralphbean
+* @ralphbean @arewm @p-rog


### PR DESCRIPTION
We are proposing to add yq-container as an acceptable base image because this is built hermetically. We should add redundancy to the owners.

ref: https://github.com/release-engineering/rhtap-ec-policy/pull/106