### PR TITLE
Align repo IDs to cpe mapping (again)

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,175 +5,175 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-2.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10802170
     checksum: sha256:0cc4a38361e1f50bce8b1c6374ea5e8fef84a6c1d7e4916d0d64bb9fb43cbaa3
     name: cpp
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-2.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 31292371
     checksum: sha256:d90c8f7694c2ffdc36fe5e32b906a1090fd7655123a448e3c1996126f9e244e9
     name: gcc
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 564979
     checksum: sha256:ad0568d684a6122506f72ba83b5868930810520dabb229c37148d489c65becc9
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/golang-1.22.9-2.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 698484
     checksum: sha256:54f96cbaea5441ad1bb3798991525b05b4b59666872a112e49a861c8ebc2c6c4
     name: golang
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/golang-bin-1.22.9-2.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 55674722
     checksum: sha256:001e59de2812ff8d0ac445cb3b8d3c12d09664d17776354356ac99cc2006a845
     name: golang-bin
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/golang-race-1.22.9-2.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 172181
     checksum: sha256:181c2083e534047a3be6cb997115507be287da39ab48dfda9983e55f6af10299
     name: golang-race
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/golang-src-1.22.9-2.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10671812
     checksum: sha256:9c85fd83f9410504107be1fa25891091eec413159b28a2c8c42abbee611ca99f
     name: golang-src
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-503.23.2.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 3889517
     checksum: sha256:00e33e317169bcdece4cf024919a8c78472d8c302ddbc48489fd48eabe9ce887
     name: kernel-headers
     evr: 5.14.0-503.23.2.el9_5
     sourcerpm: kernel-5.14.0-503.23.2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-2.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 417138
     checksum: sha256:6f4adda5c7eedd5e3e8c016c9af3e997dc6abe3e1e725a3b06a4df1904f255f3
     name: libasan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 67120
     checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-2.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 186649
     checksum: sha256:43f1a93dc84c873dc6c314fd8c16b926a4f532bc18ec632402a81409dc080205
     name: libubsan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 33051
     checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 4644433
     checksum: sha256:178e3b3d7afe60bc2a364eddc3e29429592040967a2ed00b66a48adb3e69036c
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5
     sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-54.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 5032427
     checksum: sha256:a8d027ff813e6701c9d0cd3fb9bf07c7e345f1624bca3ed72569315147b1d3cb
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 904635
     checksum: sha256:89f27c7e17bf4a70f1268e4fa6cfcfc605525b75b56494a94edf4d88ae8561bb
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 405687
     checksum: sha256:524412f7ce56095508190116cb8ae141737857e4447979330c3cf75ca7017e6b
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 39439
     checksum: sha256:4a3d077128ac04bac610dd9e099da41567f112245378d102f054f124e2d57342
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gettext-0.21-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1181385
     checksum: sha256:52f11ec908a17fedbf993ffd87f40f27067761440c433b0d0fd38f16b8d15ec4
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 295874
     checksum: sha256:b503ae5eaa875c8936ac6c28dec058d0febc6ce072c0046028bc471a37607f6a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-2.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 34044
     checksum: sha256:b50bb20da6b8c0adef190f4a25c0a024f805a7dc59f7dee75da56787b26230bb
     name: libatomic
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 38310
     checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 550249
     checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 45196
     checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 12398
     checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
     name: pkgconf-pkg-config
@@ -181,73 +181,73 @@ arches:
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/g/golang-1.22.9-2.el9_5.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-aarch64-appstream-source-rpms
     size: 30057708
     checksum: sha256:69d386995794728720589ed7798e9340f13a3986427c21bae24bc8aac464a415
     name: golang
     evr: 1.22.9-2.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-aarch64-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-54.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 22368671
     checksum: sha256:b9ac416d943868173a793c8f54801b595b2825c12228fdb5c656cd2d83922823
     name: binutils
     evr: 2.35.2-54.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/e/elfutils-0.191-4.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 9335734
     checksum: sha256:d3d8ebb8716c88a4d1f8ad5757040fc30ff3d2b04034e726f95aecb6711c205d
     name: elfutils
     evr: 0.191-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-2.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 81879513
     checksum: sha256:6265ed6800a784392d34941885ff6b0f0e82f38aa1e3b0849fd37b249124bc9f
     name: gcc
     evr: 11.5.0-2.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/g/gettext-0.21-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 9750918
     checksum: sha256:1b4dc42c4afa9d998cd13750e0aa73e0d3a16f6792bfc5e17d39aabd9c68426d
     name: gettext
     evr: 0.21-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/g/glibc-2.34-125.el9_5.1.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 18727742
     checksum: sha256:a80b272db684a3386983a445e07d1b36c3e6fc723eb93ecf89cae7d08970fd83
     name: glibc
     evr: 2.34-125.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 17984798
     checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
     name: openssl
     evr: 1:3.2.2-6.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-aarch64-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf
@@ -256,175 +256,175 @@ arches:
 - arch: ppc64le
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/cpp-11.5.0-2.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 9622015
     checksum: sha256:f7ce4ee8919093bacd353c817895a02146ddd690b408a45ecab8a9fe94fefab8
     name: cpp
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/gcc-11.5.0-2.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 29061709
     checksum: sha256:83e54db613cd5e75cb459349efe6c990ae6d76d8316eb5d3e018484008ce345e
     name: gcc
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 576530
     checksum: sha256:96d113f707cbd21b4b844b1cca46144c0d5f8e2a5a1b95050e4e3fd1773078f8
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/golang-1.22.9-2.el9_5.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 698615
     checksum: sha256:9528a7e28fef302f00ddde20a2ee63560ffde0f72b7688e2ae29ee6e208727db
     name: golang
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/golang-bin-1.22.9-2.el9_5.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 56426904
     checksum: sha256:9e117e93d9e913d661f75d0a465d1d1dfb53b6c82739d8b448f934749380a063
     name: golang-bin
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/golang-race-1.22.9-2.el9_5.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 193310
     checksum: sha256:1bd938d3999d0c2879c9cf2e6621f05ce9051d692a331e903fc656f19a2ceead
     name: golang-race
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/g/golang-src-1.22.9-2.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 10671812
     checksum: sha256:9c85fd83f9410504107be1fa25891091eec413159b28a2c8c42abbee611ca99f
     name: golang-src
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-503.23.1.el9_5.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 3911197
     checksum: sha256:916b86ac1091c7aa2aea8156deb52ede24e9eeeddccc60c043dcd93bbff84269
     name: kernel-headers
     evr: 5.14.0-503.23.1.el9_5
     sourcerpm: kernel-5.14.0-503.23.1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libasan-11.5.0-2.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 449081
     checksum: sha256:6526b2e2c6c69cc86f6a5bfe22310d84d523527624f690e7b0be0ae59a836311
     name: libasan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libmpc-1.2.1-4.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 71343
     checksum: sha256:12c0bd83a7321dccd6c715d149cb6f12299e13a1e09732a629003b0140ad9b32
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libubsan-11.5.0-2.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 209715
     checksum: sha256:cef9b943dbcbbfae7105674553883f80368125105281fb4f609b42842be76a16
     name: libubsan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 33082
     checksum: sha256:0897868b5e5ab66225dd55f585076975a84e3fd68b93a38be1d8a231d441bc16
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.ppc64le.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 4651141
     checksum: sha256:5c444fbe89e14c14d0c3d41cad70706e4c6ae546c0b2a241699ce51d00bc823c
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5
     sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/binutils-2.35.2-54.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 5216046
     checksum: sha256:17e1bb0ba09eeb82a4a27429473d0612803d7311b8b1d59076ab6ff273095cfb
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 1066913
     checksum: sha256:e9bce74ed2f75873f144a6c8607e9be728b9664ab65307b42e389f9e9461f215
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/d/diffutils-3.7-12.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 426776
     checksum: sha256:1e58188524109f7f021d2a4a7b7ac5ab9ecab60dba1b1a0defc950a0f3b91f64
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 41690
     checksum: sha256:3dd7d55d06d5cda2e2ddafdf06e1f4880efd3852b01e02f9c440162a81bb9a75
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gettext-0.21-8.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 1213573
     checksum: sha256:c3736ecb725bdba02483709480a63f3fdda58cf22a4eb5a52bcc9a6e9a655daf
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gettext-libs-0.21-8.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 335647
     checksum: sha256:0e333e7e92951bf5c4a5b556220a6a66ca52e4124c49508f64f445d415e095af
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libatomic-11.5.0-2.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 33099
     checksum: sha256:7bf16eff095b2022572a5beb2b5b5f6076aca479426713953f5f3c96e2620c5f
     name: libatomic
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 42712
     checksum: sha256:a96600fec79e7d94523816dc620203e812c4a08c82c07fb3bb62d7e9e6e1f661
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/m/make-4.3-8.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 567121
     checksum: sha256:6c3f559c10b0bfdeb892314c26622f06999b202f57d881444cc4361ec7dad88c
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 46315
     checksum: sha256:a70516a3a8f016a80613bc071586cd653db12a650c4c9f057743125cb7ad7433
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.ppc64le.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 12416
     checksum: sha256:1d641be62db76b074f4ca2d6b470d85dcf806d96e2c834337482a73984db1979
     name: pkgconf-pkg-config
@@ -432,73 +432,73 @@ arches:
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/g/golang-1.22.9-2.el9_5.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-ppc64le-appstream-source-rpms
     size: 30057708
     checksum: sha256:69d386995794728720589ed7798e9340f13a3986427c21bae24bc8aac464a415
     name: golang
     evr: 1.22.9-2.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-ppc64le-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/b/binutils-2.35.2-54.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 22368671
     checksum: sha256:b9ac416d943868173a793c8f54801b595b2825c12228fdb5c656cd2d83922823
     name: binutils
     evr: 2.35.2-54.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/e/elfutils-0.191-4.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 9335734
     checksum: sha256:d3d8ebb8716c88a4d1f8ad5757040fc30ff3d2b04034e726f95aecb6711c205d
     name: elfutils
     evr: 0.191-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/g/gcc-11.5.0-2.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 81879513
     checksum: sha256:6265ed6800a784392d34941885ff6b0f0e82f38aa1e3b0849fd37b249124bc9f
     name: gcc
     evr: 11.5.0-2.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/g/gettext-0.21-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 9750918
     checksum: sha256:1b4dc42c4afa9d998cd13750e0aa73e0d3a16f6792bfc5e17d39aabd9c68426d
     name: gettext
     evr: 0.21-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.34-125.el9_5.1.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 18727742
     checksum: sha256:a80b272db684a3386983a445e07d1b36c3e6fc723eb93ecf89cae7d08970fd83
     name: glibc
     evr: 2.34-125.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 17984798
     checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
     name: openssl
     evr: 1:3.2.2-6.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-ppc64le-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf
@@ -507,182 +507,182 @@ arches:
 - arch: s390x
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/cpp-11.5.0-2.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 8610885
     checksum: sha256:08f7f04718a246efee97f133e4287ee0c3eacd313efecad6b419b247c6fd6d3e
     name: cpp
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gcc-11.5.0-2.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 26851109
     checksum: sha256:b9ea174a2e4a1b093259aa240ac2e2ee201a8660855d6d20c90c319c6316b3cf
     name: gcc
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gettext-0.21-8.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 1183783
     checksum: sha256:9e9e3e6b40ea4ebf5fa08945938415ba48fa683955353807bb8b4ca1bd0d9a06
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/gettext-libs-0.21-8.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 295032
     checksum: sha256:4e0a504680f82132988df76ee1abcfc368006e47435ecbe04d39db70992f42b8
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 46212
     checksum: sha256:cdc8de9aa817e5b556c45de70f7cbed0b5f2fdbf06c23c75e0b7320b7a96bb03
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/glibc-headers-2.34-125.el9_5.1.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 547125
     checksum: sha256:98272b34690ad8d97921bdd136fede1f49b24bb46400d76fc853145d677ddb41
     name: glibc-headers
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/golang-1.22.9-2.el9_5.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 698831
     checksum: sha256:249eb1ba781a20b44c93b5ece199cb3b82930181ac4d013dedb98259927b12e7
     name: golang
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/golang-bin-1.22.9-2.el9_5.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 57655368
     checksum: sha256:78aaf94b8bb92966f950f0a48ee19511772715b6669cf3345d8e6059694ff308
     name: golang-bin
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/golang-race-1.22.9-2.el9_5.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 216960
     checksum: sha256:ef8457aa835209f568859bb1d35366fdfd4ebdadb5fcc618bb0c7ce06421ee55
     name: golang-race
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/g/golang-src-1.22.9-2.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 10671812
     checksum: sha256:9c85fd83f9410504107be1fa25891091eec413159b28a2c8c42abbee611ca99f
     name: golang-src
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-503.23.1.el9_5.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 3919181
     checksum: sha256:629ae5d869823ba70b674d075b1647e8f072d659c1bfd22f875a3dd6724faaff
     name: kernel-headers
     evr: 5.14.0-503.23.1.el9_5
     sourcerpm: kernel-5.14.0-503.23.1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libasan-11.5.0-2.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 421073
     checksum: sha256:2c46f017a7d8603f2617695db0e3e84f3f192d4587aac013ec80c4b4c9c88204
     name: libasan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libmpc-1.2.1-4.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 66959
     checksum: sha256:5d57ddf803a764bbbf229ccb71c8b4fbeed604b39858174d8ffee1b24510cc8c
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libubsan-11.5.0-2.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 186243
     checksum: sha256:3776344ae10780b4bb1f6671fac7f0d14a154fdff9e35820c0841b2c56a3a2bb
     name: libubsan
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 33073
     checksum: sha256:b3f6b6b72b5c96a8527e6dd46c421066f94d48f0ada76bbc638bf89f81b19360
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.s390x.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-s390x-appstream-rpms
     size: 4645678
     checksum: sha256:8b0dd90419d2e6c593a5f62b0cea65da808dc857b2ba99b32111080cd275d0c4
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5
     sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/b/binutils-2.35.2-54.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 4764973
     checksum: sha256:f2edbf1562e3a26f12712e1a9b74a1ccdde09a822da886aa1e4db2c2ccdbee0e
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 846353
     checksum: sha256:2011225002fe4fe441d9aa0719adca9496d24cce0eae87ce3e8a2bd4bdd7c97d
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/d/diffutils-3.7-12.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 410465
     checksum: sha256:a8015025ca40048059576a71f398c47d4b563e6a91e1e27a453f9212312df259
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 40103
     checksum: sha256:b1ec3a9997ad37b240f68a81468d7cc52d5e6585f19bf36c86378d3823998462
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libatomic-11.5.0-2.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 31504
     checksum: sha256:45090d5231f155cd204c00167ae61f7e92609ecd3ba558495ba45b5c4e9985ac
     name: libatomic
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 37876
     checksum: sha256:fa1da3b44d85663cceaa0faf8eb5f2f7325cc83c381d6018f303edd06cab5938
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/m/make-4.3-8.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 553451
     checksum: sha256:09c0e578e23112cb98e2234f9587fe7b6def2ae6a4b16e6d52559d546389f4d1
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 45258
     checksum: sha256:a5f966f792cacc4696e4187593a915fb56452dd272cf4c81d930968adb3ee00c
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.s390x.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-s390x-baseos-rpms
     size: 12411
     checksum: sha256:ef854bfe75102d994afb58510121164c4b9b8359b7d983cd8904c425a175b750
     name: pkgconf-pkg-config
@@ -690,67 +690,67 @@ arches:
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/golang-1.22.9-2.el9_5.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-s390x-appstream-source-rpms
     size: 30057708
     checksum: sha256:69d386995794728720589ed7798e9340f13a3986427c21bae24bc8aac464a415
     name: golang
     evr: 1.22.9-2.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-s390x-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/b/binutils-2.35.2-54.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 22368671
     checksum: sha256:b9ac416d943868173a793c8f54801b595b2825c12228fdb5c656cd2d83922823
     name: binutils
     evr: 2.35.2-54.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/e/elfutils-0.191-4.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 9335734
     checksum: sha256:d3d8ebb8716c88a4d1f8ad5757040fc30ff3d2b04034e726f95aecb6711c205d
     name: elfutils
     evr: 0.191-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/g/gcc-11.5.0-2.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 81879513
     checksum: sha256:6265ed6800a784392d34941885ff6b0f0e82f38aa1e3b0849fd37b249124bc9f
     name: gcc
     evr: 11.5.0-2.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/g/glibc-2.34-125.el9_5.1.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 18727742
     checksum: sha256:a80b272db684a3386983a445e07d1b36c3e6fc723eb93ecf89cae7d08970fd83
     name: glibc
     evr: 2.34-125.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 17984798
     checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
     name: openssl
     evr: 1:3.2.2-6.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-s390x-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf
@@ -759,161 +759,161 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-2.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11230619
     checksum: sha256:2b189824d2356256a8ec253328c3b0008a1471a8118979b40619390392386a81
     name: cpp
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-2.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 33987673
     checksum: sha256:56630979170d1ca483b039297a6d55f3f0eeedf557772d405eccb4acc3ef01c4
     name: gcc
     evr: 11.5.0-2.el9
     sourcerpm: gcc-11.5.0-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38332
     checksum: sha256:7ad500371d5034800ab8f5c6b4dd896801b1a97baa6a57bc6c982787afff2b20
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-125.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 556355
     checksum: sha256:16c84102b4457fc60ab9e46fd235bed4c9ac9dddf5cfeae3df51a5f00ce2dd5e
     name: glibc-headers
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/golang-1.22.9-2.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 698742
     checksum: sha256:6e8e65a34e18950b703651d8c61c2d5f323205c2f26b864085af604ce1b8164a
     name: golang
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/golang-bin-1.22.9-2.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 60247072
     checksum: sha256:a94f88226be0456a876601c48ed2a1cdd7dac5ed4791cb0556cc7469e5f87075
     name: golang-bin
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/golang-race-1.22.9-2.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 209545
     checksum: sha256:90696c08b3e30668afdb4d369a98ecb3f3c4a657262f64b20458c10fbd4b2c35
     name: golang-race
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/golang-src-1.22.9-2.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 10671812
     checksum: sha256:9c85fd83f9410504107be1fa25891091eec413159b28a2c8c42abbee611ca99f
     name: golang-src
     evr: 1.22.9-2.el9_5
     sourcerpm: golang-1.22.9-2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-503.23.2.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 3928049
     checksum: sha256:09e80c23581375ba3f26ef443862f65a3bbab776638c9a6d847d76d1331e1ccd
     name: kernel-headers
     evr: 5.14.0-503.23.2.el9_5
     sourcerpm: kernel-5.14.0-503.23.2.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 66075
     checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 33101
     checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 4645464
     checksum: sha256:ec2c04ad3402fc236767674ea0591cbd2cc0dd5c780aa35ac03961002a703cde
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5
     sourcerpm: openssl-3.2.2-6.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-54.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 4816328
     checksum: sha256:58286130e67839b931412baa9cb1efcb42d02dc3d1b84caed2ba711773c47ec9
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 752302
     checksum: sha256:44ace5e347a8aaad0ae8a449c5d87f69314def94b45bbd1a22a6bd827b549d95
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 411559
     checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 39913
     checksum: sha256:9c26ab1eea196541d9cde34a96acbf8647746ccd0447ad353dec5ec4225826a5
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1193150
     checksum: sha256:febf6aec8699ca352aba5a7a249ed0cb011b68c5bab17f6178f09b1035974dde
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 313328
     checksum: sha256:b319325e941e03e3e7381161889ab39473398194786a52fc1653d025211b6e1a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 38387
     checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 553896
     checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 45675
     checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 12438
     checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
     name: pkgconf-pkg-config
@@ -921,73 +921,73 @@ arches:
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/golang-1.22.9-2.el9_5.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-x86_64-appstream-source-rpms
     size: 30057708
     checksum: sha256:69d386995794728720589ed7798e9340f13a3986427c21bae24bc8aac464a415
     name: golang
     evr: 1.22.9-2.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: ubi-9-appstream-source-rpms
+    repoid: ubi-9-for-x86_64-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-54.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 22368671
     checksum: sha256:b9ac416d943868173a793c8f54801b595b2825c12228fdb5c656cd2d83922823
     name: binutils
     evr: 2.35.2-54.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.191-4.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 9335734
     checksum: sha256:d3d8ebb8716c88a4d1f8ad5757040fc30ff3d2b04034e726f95aecb6711c205d
     name: elfutils
     evr: 0.191-4.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-2.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 81879513
     checksum: sha256:6265ed6800a784392d34941885ff6b0f0e82f38aa1e3b0849fd37b249124bc9f
     name: gcc
     evr: 11.5.0-2.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/gettext-0.21-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 9750918
     checksum: sha256:1b4dc42c4afa9d998cd13750e0aa73e0d3a16f6792bfc5e17d39aabd9c68426d
     name: gettext
     evr: 0.21-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-125.el9_5.1.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 18727742
     checksum: sha256:a80b272db684a3386983a445e07d1b36c3e6fc723eb93ecf89cae7d08970fd83
     name: glibc
     evr: 2.34-125.el9_5.1
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 17984798
     checksum: sha256:b58aa63f681560c0c4716ef22de299dcfd3219fd4de4b9f0d363648c59b92f37
     name: openssl
     evr: 1:3.2.2-6.el9_5
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: ubi-9-baseos-source-rpms
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,60 +1,60 @@
-[ubi-9-baseos-rpms]
+[ubi-9-for-$basearch-baseos-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-baseos-debug-rpms]
+[ubi-9-for-$basearch-baseos-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-baseos-source-rpms]
+[ubi-9-for-$basearch-baseos-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-rpms]
+[ubi-9-for-$basearch-appstream-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-debug-rpms]
+[ubi-9-for-$basearch-appstream-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-source-rpms]
+[ubi-9-for-$basearch-appstream-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-rpms]
+[ubi-9-for-$basearch-codeready-builder-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-debug-rpms]
+[ubi-9-for-$basearch-codeready-builder-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-source-rpms]
+[ubi-9-for-$basearch-codeready-builder-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
 enabled = 1


### PR DESCRIPTION
This was fixed in https://github.com/konflux-ci/yq-container/pull/94 but then reverted in https://github.com/konflux-ci/yq-container/pull/107