### PR TITLE
Replace deprecated git-clone image with task-runner image

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -167,7 +167,7 @@ spec:
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     - name: SCRIPT_RUNNER_IMAGE
-      value: quay.io/konflux-ci/git-clone@sha256:4e53ebd9242f05ca55bfc8d58b3363d8b9d9bc3ab439d9ab76cdbdf5b1fd42d9
+      value: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
     - name: SCRIPT
       value: ./submodule.sh
     - name: HERMETIC


### PR DESCRIPTION
Use the `task-runner` image instead of deprecated `git-clone` image as SCRIPT_RUNNER_IMAGE.

## Summary by Sourcery

Build:
- Switch SCRIPT_RUNNER_IMAGE from the deprecated konflux-ci git-clone image to the konflux-ci task-runner:2.0.0 image in the Tekton build pipeline.